### PR TITLE
Update list of supported printers

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,11 @@ Supported printers (some might have quirks)
 	PT-E500
 	PT-P700
 	PT-P750W
+	PT-D410
 	PT-D450
 	PT-D460BT
 	PT-D600
+	PT-D610BT
 	PT-P710BT
 ```
 


### PR DESCRIPTION
Hi!  This repo is a really useful reference for these label printers, so I thought it might be helpful to update the list of supported printers that people see in the README.

Commit message:
```
This is as of commit 8aaeecd84b619587dc3885dd4fea4b7310c82fd4 from 2024-02-11.

There have been no new tags since 1.5, sadly.

This commit doesn't update the version information a few lines up, because on my system it uses a different format and doesn't list the version/revision.
```